### PR TITLE
Add SciPy builder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ ENV/
 
 # vi temporaries
 *.sw[p-z]
+
+.binaris/

--- a/scipy/Dockerfile
+++ b/scipy/Dockerfile
@@ -1,0 +1,27 @@
+# Docker image to build directory for bn.
+
+# Usage:
+#
+#     docker  build --tag=pipper . && \
+#     docker run --build-arg build_dir=$PWD -v /tmp/data/:/data/
+
+FROM ubuntu:16.04 as base
+
+# SciPy installer needs dependencies, and also NumPy already
+# installed.  Cheat and install it first.
+RUN apt-get update && apt-get install -y python-dev python-pip curl && apt-get build-dep -y python-scipy
+
+# Directory to copy in for build.  After building, cp this out -- to
+# the same place.  Otherwise pip will have to rebuild everything,
+# every time.
+
+RUN mkdir /function/ /cache/
+ADD dist /function
+ADD .binaris/.pycache /cache
+COPY docker/* /function/
+WORKDIR /function/
+
+# Re-use PIP cache between runs.  Do *NOT* copy this out!
+ENV XDG_CACHE_HOME=/cache/
+
+CMD [ "./install.sh" ]

--- a/scipy/build.sh
+++ b/scipy/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Builds bolt-compatible packages from Python requirements, and copies
+# them back out to CWD.
+
+dir=`dirname $0`
+
+if [ -w /var/run/docker.sock ]; then
+    DOCKER=docker
+else
+    DOCKER='sudo docker'
+fi
+
+mkdir -p .binaris/.pycache dist
+
+$DOCKER build --tag=pipper $dir # Keep going even on failure!
+if [ -f ./requirements.txt ]; then
+  volume="-v $PWD/requirements.txt:/function/requirements.txt"
+else
+  volume=''
+fi
+$DOCKER run $volume pipper:latest
+build_status=$?
+$DOCKER run pipper:latest bash -c 'tar -C /cache -cz .' | tar -x --keep-newer -C .binaris/.pycache/
+$DOCKER run pipper:latest bash -c 'tar -C /function -cz .' | tar -x --keep-newer -C dist/
+exit $build_status

--- a/scipy/docker/install.sh
+++ b/scipy/docker/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set +e
+set -x
+
+# Installation script for requirements.txt to get around weird
+# installers for scipy and scikit-learn.  Assumes scipy dependencies
+# are already installed.
+
+PIP='pip install -t ./ --install-option=--prefix='
+
+export PYTHONPATH=$PWD          # So scikit-learn installer sees
+                                # installations to this dir.
+
+$PIP `grep '^numpy' requirements.txt`
+$PIP `grep '^scipy' requirements.txt`
+$PIP -r <(grep -v -e numpy -e scipy requirements.txt)

--- a/scipy/docker/requirements.txt
+++ b/scipy/docker/requirements.txt
@@ -1,0 +1,20 @@
+#aerospike==2.1.2
+apscheduler==3.2.0
+backoff==1.3.2
+emoji==0.4.5
+google-cloud==0.23.0
+grpcio==1.0.4
+joblib==0.11
+langdetect==1.0.7
+numpy==1.11.1
+#pybloomfiltermmap==0.3.15
+pycountry==17.1.8
+pycld2==0.31
+pylru==1.0.9
+pyyaml==3.12
+requests==2.11.1
+# (Change ordering, scikit-learn depends on numpy, scipy)
+scipy==0.18.1
+scikit-learn==0.18.1
+unicodecsv==0.14.1
+xmltodict==0.10.2


### PR DESCRIPTION
Usage:

1. Go to your Binaris directory.
2. Add `requirements.txt` (otherwise it uses its default).
3. Run `/path/to/bob/scipy/build.sh`.
4. `bn deploy functionName`.

Tested by building and deploying.